### PR TITLE
Upgrade versions and Move Changes of xacml filter feature form commons

### DIFF
--- a/features/org.wso2.carbon.identity.xacml.filter.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.xacml.filter.feature/pom.xml
@@ -40,6 +40,16 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.agent.entitlement.mediator</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.proxy</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.balana</groupId>
+                    <artifactId>org.wso2.balana</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ws.security.wso2</groupId>
+                    <artifactId>wss4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -52,14 +62,6 @@
         <dependency>
             <groupId>libthrift.wso2</groupId>
             <artifactId>libthrift</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.org.opensaml</groupId>
-            <artifactId>opensaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.orbit.joda-time</groupId>
-            <artifactId>joda-time</artifactId>
         </dependency>
     </dependencies>
 
@@ -93,13 +95,10 @@
                                 <bundleDef>org.wso2.carbon.identity.framework:org.wso2.carbon.identity.entitlement.stub
                                 </bundleDef>
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.authenticator.stub</bundleDef>
-                                <bundleDef>org.wso2.orbit.org.opensaml:opensaml</bundleDef>
-                                <bundleDef>org.wso2.orbit.joda-time:joda-time</bundleDef>
                             </bundles>
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.version}</importFeatureDef>
-                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${identity.framework.version}</importFeatureDef>
-                                <importFeatureDef>org.apache.synapse.wso2:compatible:${wso2.synapse.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernel.version}
+                                </importFeatureDef>
                             </importFeatures>
                         </configuration>
                     </execution>

--- a/features/org.wso2.carbon.identity.xacml.filter.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.xacml.filter.feature/pom.xml
@@ -97,8 +97,9 @@
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.authenticator.stub</bundleDef>
                             </bundles>
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernel.version}
-                                </importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${identity.framework.version}</importFeatureDef>
+                                <importFeatureDef>org.apache.synapse.wso2:compatible:${carbon.mediation.version}</importFeatureDef>
                             </importFeatures>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -250,9 +250,9 @@
 
     <properties>
         <!--Carbon Identity Framework Version-->
-        <identity.framework.version>5.5.0</identity.framework.version>
+        <identity.framework.version>5.12.283</identity.framework.version>
 
-        <identity.agent.entitlement.proxy.version>5.1.3</identity.agent.entitlement.proxy.version>
+        <identity.agent.entitlement.proxy.version>5.1.5</identity.agent.entitlement.proxy.version>
         <identity.agent.entitlement.proxy.import.version.range>[5.0.0, 6.0.0)</identity.agent.entitlement.proxy.import.version.range>
         <identity.agent.entitlement.filter.export.version>${project.version}</identity.agent.entitlement.filter.export.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <identity.agent.entitlement.filter.export.version>${project.version}</identity.agent.entitlement.filter.export.version>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.4.7</carbon.kernel.version>
+        <carbon.kernel.version>4.4.38</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
 
         <!-- Axiom Version -->
@@ -287,7 +287,7 @@
         <opensaml2.wso2.version>2.6.4.wso2v5</opensaml2.wso2.version>
         <opensaml2.wso2.osgi.version.range>[2.6.0,3.0.0)</opensaml2.wso2.osgi.version.range>
 
-        <wso2.synapse.version>2.1.1-wso2v1</wso2.synapse.version>
+        <carbon.mediation.version>4.6.118</carbon.mediation.version>
         
         <joda.version>2.8.2</joda.version>
         <joda.wso2.version>2.8.2.wso2v1</joda.wso2.version>


### PR DESCRIPTION
Since org.wso2.carbon.identity.xacml.filter.feature is duplicated in commons

https://github.com/wso2-extensions/identity-agent-entitlement-filter/tree/master/features/org.wso2.carbon.identity.xacml.filter.feature

and here,

this PR is to move the changes from commons to here so that product EI can use this dependency.

This is done to avoid duplicate jars
https://github.com/wso2/product-ei/issues/2061
 